### PR TITLE
Fix request response verification

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,10 +79,7 @@
 
 - name: Verify windows_exporter is responding to requests.
   win_uri:
-    url: http://localhost:{{ windows_exporter_listen_port }}/
-    return_content: true
-  register: metrics_output
-  failed_when: "'Metrics' not in metrics_output.content"
+    url: http://localhost:{{ windows_exporter_listen_port }}/metrics
   when:
     - windows_exporter_start_mode != 'disabled'
     - windows_exporter_start_mode != 'manual'


### PR DESCRIPTION
I don't know since which windows_exporter version this has stopped working, or if it ever worked properly, but this check did not work on version 0.28.2 / Windows Server 2019. But I think just checking if the requests for `/metrics` are going through should be enough, no?
I've tested this with the exporter service enabled, and disabled, both gave the correct results.