### PR TITLE
allow more flexibility for configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,14 @@
 ---
 # See available releases: https://github.com/prometheus/windows_exporter/releases/
-windows_exporter_version: '0.18.1'
+windows_exporter_version: '0.31.3'
 windows_exporter_arch: 'amd64'
 windows_exporter_download_url: https://github.com/prometheus-community/windows_exporter/releases/download/v{{ windows_exporter_version }}/windows_exporter-{{ windows_exporter_version }}-{{ windows_exporter_arch }}.msi
 windows_exporter_options: []
 windows_exporter_bin_path: '"C:\Program Files\windows_exporter\windows_exporter.exe"'
+windows_exporter_config_path: 'C:\Program Files\windows_exporter\config.yaml'
 windows_exporter_state: started
 windows_exporter_start_mode: delayed
 windows_exporter_allow_from: 'any'
 windows_exporter_listen_address: '0.0.0.0'
-windows_exporter_listen_port: 9182
+windows_exporter_listen_port: 9100
 windows_exporter_textfile_dir: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,12 +3,13 @@
 windows_exporter_version: '0.31.3'
 windows_exporter_arch: 'amd64'
 windows_exporter_download_url: https://github.com/prometheus-community/windows_exporter/releases/download/v{{ windows_exporter_version }}/windows_exporter-{{ windows_exporter_version }}-{{ windows_exporter_arch }}.msi
-windows_exporter_options: []
+windows_exporter_options: |
+  telemetry:
+    path: /metrics
+  web:
+    listen-address: "0.0.0.0:9182"
 windows_exporter_bin_path: '"C:\Program Files\windows_exporter\windows_exporter.exe"'
 windows_exporter_config_path: 'C:\Program Files\windows_exporter\config.yaml'
 windows_exporter_state: started
 windows_exporter_start_mode: delayed
 windows_exporter_allow_from: 'any'
-windows_exporter_listen_address: '0.0.0.0'
-windows_exporter_listen_port: 9100
-windows_exporter_textfile_dir: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,21 +26,23 @@
     or not windows_exporter_installed_check.stat.exists
   register: windows_exporter_download_check
 
-- name: Write options to config.yml
+- name: Extract listen-address from options
+  set_fact:
+    windows_exporter_listen_address: "{{ (windows_exporter_options | from_yaml).web['listen-address'].split(':')[0] | default('0.0.0.0') }}"
+    windows_exporter_listen_port: "{{ (windows_exporter_options | from_yaml).web['listen-address'].split(':')[1] | default('9182') }}"
+    windows_exporter_telemetry_path: "{{ (windows_exporter_options | from_yaml).telemetry.path | default('/metrics') }}"
+
+- name: Write options to config file
   win_copy:
     dest: '{{ windows_exporter_config_path }}'
     content: "{{ windows_exporter_options }}"
-  when: >
-    windows_exporter_version_check.stderr is not defined
-    or windows_exporter_version not in windows_exporter_version_check.stderr
-    or not windows_exporter_installed_check.stat.exists
-  register: windows_exporter_config_write_check
   notify: restart windows_exporter
 
-- name: install Windows exporter
+- name: Install Windows exporter
   win_package:
     path: '{{ ansible_env.TEMP }}\windows_exporter_install.msi'
     state: present
+    arguments: 'CONFIG_FILE="{{ windows_exporter_config_path }}"'
   when: >
     windows_exporter_version_check.stderr is not defined
     or windows_exporter_version not in windows_exporter_version_check.stderr
@@ -48,7 +50,7 @@
   register: windows_exporter_install_check
   notify: restart windows_exporter
 
-- name: find firewall status
+- name: Find firewall status
   win_shell: Get-NetFirewallProfile | Where-Object {$_.Enabled -eq $true} | fl Enabled
   changed_when: false
   register: firewall_enabled
@@ -73,7 +75,7 @@
 
 - name: Verify windows_exporter is responding to requests.
   win_uri:
-    url: http://localhost:{{ windows_exporter_listen_port }}/metrics
+    url: http://{{ windows_exporter_listen_address }}:{{ windows_exporter_listen_port }}{{ windows_exporter_telemetry_path }}
     return_content: true
   register: metrics_output
   failed_when: metrics_output.status_code != 200

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,27 +26,21 @@
     or not windows_exporter_installed_check.stat.exists
   register: windows_exporter_download_check
 
-- name: create options string
-  tags:
-    test
-  block:
-    - name: list all options
-      set_fact:
-        windows_exporter_options: "{{ windows_exporter_options|default([]) + [item.key + '=' + item.value|string] if item.value is defined }}"
-      with_dict:
-        - LISTEN_ADDR: "{{ windows_exporter_listen_address }}"
-        - LISTEN_PORT: "{{ windows_exporter_listen_port }}"
-        - TEXTFILE_DIR: "{{ windows_exporter_textfile_dir }}"
-
-    - name: concatenate options to parameter string
-      set_fact:
-        windows_exporter_options_string: "{{ ' '.join(windows_exporter_options) }}"
+- name: Write options to config.yml
+  win_copy:
+    dest: '{{ windows_exporter_config_path }}'
+    content: "{{ windows_exporter_options }}"
+  when: >
+    windows_exporter_version_check.stderr is not defined
+    or windows_exporter_version not in windows_exporter_version_check.stderr
+    or not windows_exporter_installed_check.stat.exists
+  register: windows_exporter_config_write_check
+  notify: restart windows_exporter
 
 - name: install Windows exporter
   win_package:
     path: '{{ ansible_env.TEMP }}\windows_exporter_install.msi'
     state: present
-    arguments: "{{ windows_exporter_options_string }}"
   when: >
     windows_exporter_version_check.stderr is not defined
     or windows_exporter_version not in windows_exporter_version_check.stderr
@@ -79,10 +73,10 @@
 
 - name: Verify windows_exporter is responding to requests.
   win_uri:
-    url: http://localhost:{{ windows_exporter_listen_port }}/
+    url: http://localhost:{{ windows_exporter_listen_port }}/metrics
     return_content: true
   register: metrics_output
-  failed_when: "'Metrics' not in metrics_output.content"
+  failed_when: metrics_output.status_code != 200
   when:
     - windows_exporter_start_mode != 'disabled'
     - windows_exporter_start_mode != 'manual'


### PR DESCRIPTION
Trying to add complicated parameters with lots of nested quotes (such as regexes and where clauses) to EXTRA_FLAGS in the MSI installer is complex if at all possible.

Writing the options to the config.yaml file is a cleaner option without the headache. Restarting windows_exporter on config change also makes better sense, because as it is currently, a config change won't take effect if a newer version of windows_exporter isn't also installed.